### PR TITLE
Fixed compatibility to zabbix agent 3.4

### DIFF
--- a/zabbix_agentd.d/apt.conf
+++ b/zabbix_agentd.d/apt.conf
@@ -2,5 +2,5 @@
 # This is just a simulation, that can be run under zabbix user
 # Since updating packages lists (apt-get update) requires root user,
 # use APT::Periodic or some other functionality for that
-UserParameter=apt.security,apt-get -s upgrade | grep -ci ^inst.*security
-UserParameter=apt.updates,apt-get -s upgrade | grep -iPc '^Inst((?!security).)*$'
+UserParameter=apt.security,apt-get -s upgrade | grep -ci ^inst.*security|perl -pe 'chomp if eof'
+UserParameter=apt.updates,apt-get -s upgrade | grep -iPc '^Inst((?!security).)*$'|perl -pe 'chomp if eof'


### PR DESCRIPTION
Zabbix 3.4 is not accepting newline for numeric results. This commit is fixing this issue.