### PR TITLE
Fix APT commands to correctly detect security updates

### DIFF
--- a/zabbix_agentd.d/apt.conf
+++ b/zabbix_agentd.d/apt.conf
@@ -3,4 +3,4 @@
 # Since updating packages lists (apt-get update) requires root user,
 # use APT::Periodic or some other functionality for that
 UserParameter=apt.security,apt-get -s dist-upgrade | grep -ci '^\s*Inst.*security.*' | tr -d '\n'
-UserParameter=apt.updates,apt-get -s dist-upgrade | grep -c '^[^Inst].*->.*' | tr -d '\n'
+UserParameter=apt.updates,apt-get -s dist-upgrade | grep -Pc '^Inst(?:(?!security).)*$' | tr -d '\n'

--- a/zabbix_agentd.d/apt.conf
+++ b/zabbix_agentd.d/apt.conf
@@ -2,5 +2,5 @@
 # This is just a simulation, that can be run under zabbix user
 # Since updating packages lists (apt-get update) requires root user,
 # use APT::Periodic or some other functionality for that
-UserParameter=apt.security,apt-get -s upgrade | grep -ci ^inst.*security | tr -d '\n'
-UserParameter=apt.updates,apt-get -s upgrade | grep -iPc '^Inst((?!security).)*$' | tr -d '\n'
+UserParameter=apt.security,apt-get -s dist-upgrade | grep -ci '^\s*Inst.*security.*' | tr -d '\n'
+UserParameter=apt.updates,apt-get -s dist-upgrade | grep -c '^[^Inst].*->.*' | tr -d '\n'


### PR DESCRIPTION
This pull request addresses an issue where the zabbix-agent configuration was incorrectly detecting security updates in Ubuntu Jammy. The previous commands were not working as expected, resulting in zero results. To fix this, I have updated the APT commands to use 'dist-upgrade' and refined the regular expressions to accurately detect security updates.

I have tested these changes on Ubuntu Jammy and Debian Bullseye and confirmed that they now correctly identify security updates. The configuration is now in line with best practices for managing security updates.

Fixes #5

Tested on: Ubuntu 22.04.3 LTS (Jammy Jellyfish), Debian 11.7 (Bullseye)